### PR TITLE
null check while validating the move , horde constructor fix

### DIFF
--- a/ChessDotNet.Variants.Tests/AtomicChessGameTests.cs
+++ b/ChessDotNet.Variants.Tests/AtomicChessGameTests.cs
@@ -292,7 +292,6 @@ namespace ChessDotNet.Variants.Tests
             Assert.Throws<NotImplementedException>(() => game.Undo());
         }
 
-
         [Test]
         public static void ValidateThatEmptyCannotMove()
         {

--- a/ChessDotNet.Variants.Tests/AtomicChessGameTests.cs
+++ b/ChessDotNet.Variants.Tests/AtomicChessGameTests.cs
@@ -291,5 +291,15 @@ namespace ChessDotNet.Variants.Tests
             game.MakeMove(new Move("E4", "D5", Player.White), true);
             Assert.Throws<NotImplementedException>(() => game.Undo());
         }
+
+
+        [Test]
+        public static void ValidateThatEmptyCannotMove()
+        {
+            AtomicChessGame game = new AtomicChessGame();
+            var move = new Move("c3", "c4", Player.White);
+            var valid = game.IsValidMove(move);
+            Assert.IsFalse(valid);
+        }
     }
 }

--- a/ChessDotNet.Variants.Tests/HordeChessGameTests.cs
+++ b/ChessDotNet.Variants.Tests/HordeChessGameTests.cs
@@ -3,6 +3,7 @@
 namespace ChessDotNet.Variants.Tests
 {
     using Horde;
+    using System.Collections.Generic;
 
     [TestFixture]
     public class HordeChessGameTests
@@ -186,6 +187,18 @@ namespace ChessDotNet.Variants.Tests
             game.MakeMove(new Move("A7", "B8", Player.White, 'Q'), true);
             Assert.True(game.Undo());
             Assert.AreEqual(fen, game.GetFen());
+        }
+
+        [Test]
+        public static void TestConstructorWithMoves()
+        {
+            var move = new Move("h4", "h5", Player.White);
+            var moves = new List<Move>();
+            moves.Add(move);
+            
+            HordeChessGame game = new HordeChessGame(moves, true);
+            var p = game.GetPieceAt(File.H, 5);
+            Assert.IsNotNull(p);
         }
     }
 }

--- a/ChessDotNet.Variants/Atomic/AtomicChessGame.cs
+++ b/ChessDotNet.Variants/Atomic/AtomicChessGame.cs
@@ -67,7 +67,7 @@ namespace ChessDotNet.Variants.Atomic
                 return false;
             Piece piece = GetPieceAt(move.OriginalPosition.File, move.OriginalPosition.Rank);
             if (careAboutWhoseTurnItIs && move.Player != WhoseTurn) return false;
-            if (piece.Owner != move.Player) return false;
+            if (piece == null || piece.Owner != move.Player) return false;
             Piece pieceAtDestination = GetPieceAt(move.NewPosition);
             if (pieceAtDestination != null)
             {

--- a/ChessDotNet.Variants/Horde/HordeChessGame.cs
+++ b/ChessDotNet.Variants/Horde/HordeChessGame.cs
@@ -1,7 +1,9 @@
 ﻿using ChessDotNet.Pieces;
 using ChessDotNet.Variants.Horde.Pieces;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace ChessDotNet.Variants.Horde
 {
@@ -61,7 +63,19 @@ namespace ChessDotNet.Variants.Horde
         public HordeChessGame(Piece[][] board, Player whoseTurn) : base(board, whoseTurn) { }
         public HordeChessGame(GameCreationData data) : base(data) { }
         public HordeChessGame(string fen) : base(fen) { }
-        public HordeChessGame(IEnumerable<Move> moves, bool movesAreValidated) : base(moves, movesAreValidated) { }
+        public HordeChessGame(IEnumerable<Move> moves, bool movesAreValidated) : this() {
+            if (moves == null)
+                throw new ArgumentNullException("moves");
+            if (moves.Count() == 0)
+                throw new ArgumentException("The Count of moves has to be greater than 0.");
+            foreach (Move m in moves)
+            {
+                if (ApplyMove(m, movesAreValidated) == MoveType.Invalid)
+                {
+                    throw new ArgumentException("Invalid move passed to ChessGame constructor.");
+                }
+            }
+        }
 
         public override bool IsInCheck(Player player)
         {


### PR DESCRIPTION
Same check exists in ChessGame but was missing in Atomic